### PR TITLE
Normalize names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/config/credentials/development.key
+
+/config/credentials.yml.enc
+/config/credentials/*.yml.enc
 
 # MacOS
 .DS_Store
+

--- a/app/controllers/api/v1/nations.rb
+++ b/app/controllers/api/v1/nations.rb
@@ -18,7 +18,7 @@ module API
           requires :name, type: String, desc: 'The name of the nation'
         end
         get ':name' do
-          Nation.where(name: permitted_params[:name]).first!
+          Nation.where(name: permitted_params[:name].gsub(' ', '_').downcase).first!
         end
 
         desc 'Subset of nations that can be endorsed by target nation'
@@ -26,7 +26,8 @@ module API
           requires :name, type: String, desc: 'The name of the nation'
         end
         get ':name/endorsable' do
-          render Nation.has_not_endorsed(permitted_params[:name]), serializer: NationNameSerializer
+          render Nation.has_not_endorsed(permitted_params[:name].gsub(' ', '_').downcase),
+                 serializer: NationNameSerializer
         end
 
         desc 'Subset of nations that are not yet endorsing the target nation'
@@ -34,7 +35,7 @@ module API
           requires :name, type: String, desc: 'The name of the nation'
         end
         get ':name/not_endorsed_by' do
-          render Nation.not_endorsing(permitted_params[:name]), serializer: NationNameSerializer
+          render Nation.not_endorsing(permitted_params[:name].gsub(' ', '_').downcase), serializer: NationNameSerializer
         end
       end
     end

--- a/app/controllers/api/v1/regions.rb
+++ b/app/controllers/api/v1/regions.rb
@@ -18,7 +18,7 @@ module API
           requires :name, type: String, desc: 'The name of the region'
         end
         get ':name' do
-          Region.where(name: permitted_params[:name]).first!
+          Region.where(name: permitted_params[:name].gsub(' ', '_').downcase).first!
         end
       end
     end

--- a/lib/tasks/parse_dumps.rake
+++ b/lib/tasks/parse_dumps.rake
@@ -156,7 +156,7 @@ class NationParser < Nokogiri::XML::SAX::Document
   #
   def characters(string)
     case @state
-    when Constants::NationCollectors::COLLECT_NAME then @current_name += string
+    when Constants::NationCollectors::COLLECT_NAME then @current_name += string.gsub(' ', '_').downcase
     when Constants::NationCollectors::COLLECT_TYPE then @current_type += string
     when Constants::NationCollectors::COLLECT_FULLNAME then @current_fullname += string
     when Constants::NationCollectors::COLLECT_MOTTO then @current_motto += string
@@ -446,7 +446,7 @@ class RegionParser < Nokogiri::XML::SAX::Document
   #
   def characters(string)
     case @state
-    when Constants::RegionCollectors::COLLECT_NAME then @current_name += string
+    when Constants::RegionCollectors::COLLECT_NAME then @current_name += string.gsub(' ', '_').downcase
     when Constants::RegionCollectors::COLLECT_NUMNATIONS then @current_numnations += string
     when Constants::RegionCollectors::COLLECT_NATIONS
       string.split(':').each do |nation|


### PR DESCRIPTION
Fixes #5 

I ended up having to (re-)add encrypted credentials to the .gitignore — I figured there's no point tracking changes in them unless you're sharing your secret key, but tracking changes to the encrypted files without committing them was just a hassle to keep them every time I switched branches, for instance.

If I'm understanding the docs correctly, there's also a cleaner (in my opinion) way to do this: Rails 7.1 added [ActiveRecord::Normalization](https://api.rubyonrails.org/classes/ActiveRecord/Normalization.html). I haven't used it since Conductor is still at Rails ~> 7.0.3, but let me know if bumping it up is not an issue and I can look into it. Rails' built-in normalization is nice both because it avoids the need to repeatedly call the same string methods and also because it avoids any pitfalls when making queries between models (e.g. finding the region that a nation is currently in and then querying for some data about that region).